### PR TITLE
Fix and clarify readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,25 +16,35 @@ Or to make a call:
 	
 Of course, much of our interaction with Twilio is by defining resources that respond to Twilio webhooks. To respond to every SMS with a customized reply, in your server's handler method:
 
-	fn handle_request(mut req: Request, res: Response)  {
-		let client = ...;
-		client.respond_to_webhook(&mut req, res, |msg: Message|{
-			let mut t = Twiml::new();
-            t.add(&twiml::Message {txt: format!("You told me: '{}'",msg.body.unwrap())});
-            t
-		});
-	}
+```rust
+fn handle_request(mut req: Request, res: Response)  {
+    let client = ...;
+    client.respond_to_webhook(&mut req, res, |msg: Message| {
+      let mut t = Twiml::new();
+      t.add(&twiml::Message {
+          txt: format!("You told me: '{}'", msg.body.unwrap())
+      });
+      t
+    });
+}
+```
 
 Alternatively, to respond to a voice callback with a message:
 
-	fn handle_request(mut req: Request, res: Response)  {
-		let client = ...;
-		client.respond_to_webhook(&mut req, res, |msg: Call|{
-			let mut t = Twiml::new();
-			t.add(&Say{txt: "Thanks for using twilio-rs. Bye!".to_string(),voice: Woman,language: "en".to_string()});
-            t
-		});
-	}
+```rust
+fn handle_request(mut req: Request, res: Response)  {
+    let client = ...;
+    client.respond_to_webhook(&mut req, res, |msg: Call| {
+      let mut t = Twiml::new();
+      t.add(&Say {
+          txt: "Thanks for using twilio-rs. Bye!".to_string(),
+          voice: Woman,
+          language: "en".to_string()
+      });
+      t
+    });
+}
+```
 
 Using the `respond_to_webhook` method will first authenticate that the request came from Twilio, using your AuthToken. If that fails, an error will be sent to the client. Next, the call or message will be parsed from the parameters passed in. If a required field is missing, an error will be sent to the client. Finally, the parsed object will be passed to your handler method, which must return a `Twiml` that will be used to respond to the webhook.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Of course, much of our interaction with Twilio is by defining resources that res
 			let mut t = Twiml::new();
             t.add(&twiml::Message {txt: format!("You told me: '{}'",msg.body.unwrap())});
             t
-            });
 		});
 	}
 
@@ -34,7 +33,6 @@ Alternatively, to respond to a voice callback with a message:
 			let mut t = Twiml::new();
 			t.add(&Say{txt: "Thanks for using twilio-rs. Bye!".to_string(),voice: Woman,language: "en".to_string()});
             t
-            });
 		});
 	}
 


### PR DESCRIPTION
I'm playing around with your twilio library for a project I'm working on. I tried to use the README examples first, but they are not syntatically valid. The examples in the `examples` folder were very helpful though. Great work on this!