### PR TITLE
+ is replaced with its URL-encoded counterpart %2B

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ fn url_encode(params: &[(&str,&str)]) -> String {
     }).fold("".to_string(), |mut acc, item| {
         acc.push_str(&item);
         acc.push_str("&");
-        acc
+        acc.replace("+", "%2B")
     })
 }
 


### PR DESCRIPTION
I keep getting HTTP Error 400 Bad request, on my request. After consulting WireShark i discovered that the + sign used in my phone number disappeared (replaced by a "space"), somewhere after the request where send in hyper. But if the plus sign is replaced with its URL-encoded counterpart %2B, its survives unto the metal. And the request is successful.

p.s Thank you for an awesome crate ;) I'm new in the rust world, so my solution could be really bad, please let me know.
