### PR TITLE
Update webhooks example to use modified Hyper Server API

### DIFF
--- a/examples/webhooks.rs
+++ b/examples/webhooks.rs
@@ -35,7 +35,7 @@ fn responder(mut req: Request, res: Response) {
 }
 
 fn main() {
-    let _listening = hyper::Server::http(responder)
-        .listen("127.0.0.1:3000").unwrap();
+    let server = hyper::Server::http("127.0.0.1:3000").unwrap();
+    let _guard = server.handle(responder);
     println!("Listening on http://127.0.0.1:3000");
 }


### PR DESCRIPTION
The webhooks example does not compile, due to changes in Hyper. 
