### PR TITLE
Make authentication optional

### DIFF
--- a/examples/call.rs
+++ b/examples/call.rs
@@ -1,11 +1,12 @@
+use std::env;
 extern crate twilio;
 use twilio::{Client,Call,OutboundCall};
 fn main() {
-    let to = "<to-number>";
-    let from = "<from-number>";
+    let to = &env::var("TWILIO_ACCOUNT_PHONE_NUMBER").unwrap();
+    let from = &env::var("TWILIO_TESTER_PHONE_NUMBER").unwrap();
     let url = "http://demo.twilio.com/welcome/voice/";
-    let app_id = "my_app_id";
-    let auth_token = "my_auth_token";
+    let app_id = &env::var("TWILIO_APP_ID").unwrap();
+    let auth_token = &env::var("TWILIO_AUTH_TOKEN").unwrap();
     let client = Client::new(app_id,auth_token);
     let call = OutboundCall::new(from,to,url);
     match client.make_call(call) {

--- a/examples/sms.rs
+++ b/examples/sms.rs
@@ -1,11 +1,12 @@
+use std::env;
 extern crate twilio;
 use twilio::{Client,OutboundMessage};
 fn main() {
-    let to = "<to-number>";
-    let from = "<from-number>";
+    let to = &env::var("TWILIO_TESTER_PHONE_NUMBER").unwrap();
+    let from = &env::var("TWILIO_ACCOUNT_PHONE_NUMBER").unwrap();
     let body = "Hello, World! ";
-    let app_id = "<app-id>";
-    let auth_token = "<auth-token>";
+    let app_id = &env::var("TWILIO_APP_ID").unwrap();
+    let auth_token = &env::var("TWILIO_AUTH_TOKEN").unwrap();
     let client = Client::new(app_id,auth_token);
     let msg = OutboundMessage::new(from,to,body);
     match client.send_message(msg) {

--- a/examples/webhooks.rs
+++ b/examples/webhooks.rs
@@ -11,7 +11,9 @@ use twilio::twiml::{Twiml,Voice,Say};
 fn responder(mut req: Request, res: Response) {
     let app_id = &env::var("TWILIO_APP_ID").unwrap();
     let auth_token = &env::var("TWILIO_AUTH_TOKEN").unwrap();
-    let client = twilio::Client::new(app_id,auth_token);
+    let mut client = twilio::Client::new(app_id,auth_token);
+    // With a test application server using HTTP rather than HTTPS, uncomment the following line
+    //client.disable_authentication();
     let cloned_uri = match req.uri {
         AbsolutePath(ref path) => path.clone(),
         _ => panic!("Unexpected path type."),

--- a/examples/webhooks.rs
+++ b/examples/webhooks.rs
@@ -35,7 +35,7 @@ fn responder(mut req: Request, res: Response) {
 }
 
 fn main() {
-    let _listening = hyper::Server::http(responder)
-        .listen("127.0.0.1:3000").unwrap();
+    let server = hyper::Server::http("127.0.0.1:3000").unwrap();
+    let _guard = server.handle(responder);
     println!("Listening on http://127.0.0.1:3000");
 }

--- a/examples/webhooks.rs
+++ b/examples/webhooks.rs
@@ -2,13 +2,15 @@ extern crate hyper;
 extern crate twilio;
 extern crate mime;
 
+use std::env;
+
 use hyper::server::{Request, Response};
 use hyper::uri::RequestUri::AbsolutePath;
 use twilio::twiml::{Twiml,Voice,Say};
 
 fn responder(mut req: Request, res: Response) {
-    let app_id = "<app-id>";
-    let auth_token = "<auth-token>";
+    let app_id = &env::var("TWILIO_APP_ID").unwrap();
+    let auth_token = &env::var("TWILIO_AUTH_TOKEN").unwrap();
     let client = twilio::Client::new(app_id,auth_token);
     let cloned_uri = match req.uri {
         AbsolutePath(ref path) => path.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub struct Client {
     account_id : String,
     auth_token : String,
     auth_header : Authorization<Basic>,
+    authenticate : bool,
 }
 fn url_encode(params: &[(&str,&str)]) -> String {
     params.iter().map(|&t| {
@@ -53,8 +54,14 @@ impl Client {
             account_id : account_id.to_string(),
             auth_token : auth_token.to_string(),
             auth_header : basic_auth_header(account_id.to_string(),auth_token.to_string()),
+            authenticate : true,
         }
     }
+
+    pub fn disable_authentication(&mut self) {
+        self.authenticate = false;
+    }
+
     fn send_request<T : rustc_serialize::Decodable>(&self, method: hyper::method::Method, endpoint: &str, params: &[(&str,&str)]) -> Result<T,TwilioError> {
         let url = format!("https://api.twilio.com/2010-04-01/Accounts/{}/{}.json",self.account_id,endpoint);
         let mut http_client = hyper::Client::new();


### PR DESCRIPTION
This library currently assumes that HTTPS will be used as discussed [here](https://www.twilio.com/docs/api/security). 

This change would allow testing to be done using HTTP. This would allow a new user to test the library more quickly without having to put a certificate on their test server. 