### PR TITLE
Support TLS via hyper-native-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["twilio","rust"]
 
 [dependencies]
 hyper = "^0.10"
+hyper-native-tls = "^0.2"
 rustc-serialize="^0.3"
 mime = "^0.2"
 rust-crypto = "^0.2"


### PR DESCRIPTION
As of 0.10.0, hyper no longer provides OpenSSL support out of the box and requires that TLS support be added in from other crates. [hyper-native-tls](https://crates.io/crates/hyper-native-tls) is such a crate.

Without this, on OS X at least, calls to the Twilio API fail with `NetworkError`.