### PR TITLE
Add additional error type to show Twilio error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
+/.idea
 Cargo.lock
 .env


### PR DESCRIPTION
Added one new `TwilioError `member to handle HTTP 400 error responses and to keep original error messages and codes.

The problem was, that original error messages and error codes from Twilio were lost which would lead to a lot of pain tracking the errors in production. This is fixed by handling all HTTP 400 Twilio API responses with dedicated `TwilioError ` member