### PR TITLE
Using serde_qs for object serialization to query strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,11 @@ base64 = "0.12"
 headers = "0.3.2"
 hyper = "0.13"
 hyper-tls = "0.4"
+log = "0.4"
 mime = "0.3"
 serde = { version = "1.0.10", features = ["derive"] }
 serde_json = "1.0.2"
+serde_urlencoded = "0.7"
 rust-crypto = "0.2"
 url = "2.0"
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -1,7 +1,9 @@
 use crate::{Client, FromMap, TwilioError, POST};
 use serde::Deserialize;
+use serde::Serialize;
 use std::collections::BTreeMap;
 
+#[derive(Debug, Serialize)]
 pub struct OutboundCall<'a> {
     pub from: &'a str,
     pub to: &'a str,
@@ -37,12 +39,7 @@ pub struct Call {
 
 impl Client {
     pub async fn make_call(&self, call: OutboundCall<'_>) -> Result<Call, TwilioError> {
-        let opts = [
-            ("To", &*call.to),
-            ("From", &*call.from),
-            ("Url", &*call.url),
-        ];
-        self.send_request(POST, "Calls", &opts).await
+        self.send_request(POST, "Calls", &call).await
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,7 +1,9 @@
 use crate::{Client, FromMap, TwilioError, POST};
 use serde::Deserialize;
+use serde::Serialize;
 use std::collections::BTreeMap;
 
+#[derive(Debug, Serialize)]
 pub struct OutboundMessage<'a> {
     pub from: &'a str,
     pub to: &'a str,
@@ -38,8 +40,7 @@ pub struct Message {
 
 impl Client {
     pub async fn send_message(&self, msg: OutboundMessage<'_>) -> Result<Message, TwilioError> {
-        let opts = [("To", &*msg.to), ("From", &*msg.from), ("Body", &*msg.body)];
-        self.send_request(POST, "Messages", &opts).await
+        self.send_request(POST, "Messages", &msg).await
     }
 }
 


### PR DESCRIPTION
This is a modification to use https://github.com/samscott89/serde_qs for generating query string for Twilio.

I'd like to expand this library in the future and this change allows to do it easily without manually mapping the parameters to URL.

NOTES:
- Could you please run the tests? You have working configuration very likely. I am still getting setting up everything. Did a quick small test with `serde_qs` to ensure URL is generated correctly.
- Not sure if the handling `Client::send_request()` is the best. Feel free to modify this patch or reimplement as you see fit.
- Added logging which might be useful in the future