### PR TITLE
Fix issue where ampersands were not encoding correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use message::{Message, OutboundMessage};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
+use url::form_urlencoded;
 
 pub const GET: Method = Method::GET;
 pub const POST: Method = Method::POST;
@@ -26,17 +27,12 @@ pub struct Client {
 }
 
 fn url_encode(params: &[(&str, &str)]) -> String {
-    params
-        .iter()
-        .map(|&t| {
-            let (k, v) = t;
-            format!("{}={}", k, v)
-        })
-        .fold("".to_string(), |mut acc, item| {
-            acc.push_str(&item);
-            acc.push_str("&");
-            acc.replace("+", "%2B")
-        })
+    let mut url = form_urlencoded::Serializer::new(String::new());
+    for (k, v) in params {
+        url.append_pair(k, v);
+    }
+
+    url.finish()
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Test case:

Try to send a message with ampersands and spaces, for me, the string that was failing was:

```
39% through the month
✅ Gardening & Bookbinding
✅ 😘 Date Night
✅ 🥡 Restaurants
⚠️ Coffee
❌ 💃K Action Items
```

Which would truncate before the &, leaving the final text looking like:

```
✅ Gardening 
```

With this change it fixes it, sending the text I intended to send

Based on the suggestion here:
https://users.rust-lang.org/t/urlencode-in-rust/14988

and playground
https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=89b090004cf3f649460456d7e53a66c4