### PR TITLE
switch from rust-crypto (abandoned) to sha1 library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,11 @@ description = "Rust bindings for the Twilio API"
 readme = "README.md"
 repository = "https://github.com/neil-lobracco/twilio-rs"
 license = "MIT"
-authors = ["Neil LoBracco <neil.lobracco@gmail.com>", "Lance Carlson <lancecarlson@gmail.com>"]
-keywords = ["twilio","rust"]
+authors = [
+    "Neil LoBracco <neil.lobracco@gmail.com>",
+    "Lance Carlson <lancecarlson@gmail.com>",
+]
+keywords = ["twilio", "rust"]
 edition = "2018"
 
 [dependencies]
@@ -17,7 +20,7 @@ hyper-tls = "0.5"
 mime = "0.3"
 serde = { version = "1.0.10", features = ["derive"] }
 serde_json = "1.0.2"
-rust-crypto = "0.2"
+sha1 = "0.10"
 url = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
... which was already a transitive dependency. This addresses https://rustsec.org/advisories/RUSTSEC-2016-0005.html