### PR TITLE
Make MessageStatus public and add all documented enum options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use headers::{ContentType, HeaderMapExt};
 use hyper::client::connect::HttpConnector;
 use hyper::{Body, Method, StatusCode};
 use hyper_tls::HttpsConnector;
-pub use message::{Message, OutboundMessage};
+pub use message::{Message, MessageStatus, OutboundMessage};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};

--- a/src/message.rs
+++ b/src/message.rs
@@ -14,17 +14,24 @@ impl<'a> OutboundMessage<'a> {
     }
 }
 
+/// See the Twilio docs on [Message Status values](https://www.twilio.com/docs/sms/api/message-resource#message-status-values)
+/// for descriptions of the message status values.
 #[derive(Debug, Deserialize)]
-#[allow(non_camel_case_types)]
+#[serde(rename_all = "snake_case")]
 pub enum MessageStatus {
-    queued,
-    sending,
-    sent,
-    failed,
-    delivered,
-    undelivered,
-    receiving,
-    received,
+    Queued,
+    Sending,
+    Sent,
+    Failed,
+    Delivered,
+    Undelivered,
+    Receiving,
+    Received,
+    Accepted,
+    Scheduled,
+    Read,
+    PartiallyDelivered,
+    Canceled,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This change allows users of this crate access to the `MessageStatus` enum by adding it to the public API. It also adds a little documentation with a link to the Twilio docs (https://www.twilio.com/docs/sms/api/message-resource#message-status-values) and adds the few remaining status values from the docs.