### PR TITLE
Webhook authentification failed due to missing HMAC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ mime = "0.3"
 serde = { version = "1.0.10", features = ["derive"] }
 serde_json = "1.0.2"
 sha1 = "0.10"
+hmac = "0.12"
 url = "2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Hey, I noticed that the authentification of the twilio signature header wasn't working correct and tracked it down to a change in their backend security, where HMAC was added on top of the existing SHA1 algorithm. Link to their change in the documentation: https://www.twilio.com/docs/usage/security#a-note-on-hmac-sha1. Feedback appreciated