### PR TITLE
Derive `Clone` on `Client`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub const GET: Method = Method::GET;
 pub const POST: Method = Method::POST;
 pub const PUT: Method = Method::PUT;
 
+#[derive(Clone)]
 pub struct Client {
     account_id: String,
     auth_token: String,


### PR DESCRIPTION
Hi there,

For my use case with `axum` / `tower`, I needed to be able to derive `Clone` on `Client` so I could add it to a state layer within the app.

Based on the components within `Client`, this seems innocent enough - a couple of `String`s, `Authorization<Basic>` which already has `Clone` derived for it, and `hyper::Client` which states the following in the documentation:

> `Client` is cheap to clone and cloning is the recommended way to share a `Client`. The underlying connection pool will be reused.

Let me know what you think @neil-lobracco!

Thanks.

