### PR TITLE
Make `message` module public and format code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod call;
+pub mod call;
 pub mod message;
 pub mod twiml;
 mod webhook;


### PR DESCRIPTION
Thank you for creating such a wonderful crate!

I would like to discuss the `MessageStatus`. Currently, `message.rs` is not public, making it inaccessible for external use, which prevents handling through the enum.

This is how I would like to use it:

```
let twilio_message = client
    .send_message(OutboundMessage::new(&param.twilio.from_us, &param.tel, &param.content))
    .await?;

    match twilio_message.status {
        Some(twilio::message::MessageStatus::Queued) => {
            println!("Message is queued!");
            Ok(())
        },
        Some(status) => {
            println!("Message status: {:?}", status);
            Ok(())
        },
        None => {
            Err(Error::App("Failed to get message status.".to_string()))
        }
    }
```

If possible, I would appreciate it if you could make `message.rs` public.