### PR TITLE
Adding twiml support in OutboundCalls

### DIFF
--- a/src/call.rs
+++ b/src/call.rs
@@ -1,4 +1,4 @@
-use crate::{Client, FromMap, TwilioError, POST};
+use crate::{Client, FromMap, TwilioError, GET, POST};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -62,6 +62,11 @@ impl Client {
         }
 
         self.send_request(POST, "Calls", &opts).await
+    }
+
+    pub async fn retrieve_call(&self, sid: &str) -> Result<Call, TwilioError> {
+        let opts = [("Sid", sid)];
+        self.send_request(GET, "Calls", &opts).await
     }
 }
 

--- a/src/call.rs
+++ b/src/call.rs
@@ -32,7 +32,7 @@ impl<'a> OutboundCall<'a> {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum CallStatus {
     Queued,
     Ringing,

--- a/src/call.rs
+++ b/src/call.rs
@@ -65,8 +65,7 @@ impl Client {
     }
 
     pub async fn retrieve_call(&self, sid: &str) -> Result<Call, TwilioError> {
-        let opts = [("Sid", sid)];
-        self.send_request(GET, "Calls", &opts).await
+        self.send_request(GET, &format!("Calls/{sid}"), &[]).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ mod message;
 pub mod twiml;
 mod webhook;
 
-pub use call::{Call, OutboundCall};
+pub use call::{Call, CallStatus, OutboundCall};
 use headers::authorization::{Authorization, Basic};
 use headers::{ContentType, HeaderMapExt};
 use hyper::client::connect::HttpConnector;
@@ -117,8 +117,6 @@ impl Client {
 
         // Now create the request with body
         let req = req_builder.body(body).unwrap();
-
-        println!("{req:?}");
 
         let resp = self
             .http_client


### PR DESCRIPTION
This PR adds support for inlining twiml in an OutboundCall. This can be more convenient vs having to persist twiml instructions in a publically reachable URL.